### PR TITLE
New outline[] formspec element

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(gui_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/guiOutline.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiAnimatedImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBackgroundImage.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/guiBox.cpp

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1046,6 +1046,59 @@ void GUIFormSpecMenu::parseButton(parserData* data, const std::string &element)
 
 	m_fields.push_back(spec);
 }
+void GUIFormSpecMenu::parseOutline(parserData* data, const std::string &element)
+{
+    std::vector<std::string> parts = split(element, ';');
+
+    // Validate parts size and formspec version
+    if ((parts.size() == 3) ||
+        ((parts.size() > 3) && (m_formspec_version > FORMSPEC_API_VERSION)))
+    {
+        std::vector<std::string> v_pos = split(parts[0], ',');
+        std::vector<std::string> v_geom = split(parts[1], ',');
+
+        MY_CHECKPOS("outline", 0);
+        MY_CHECKGEOM("outline", 1);
+
+        v2s32 pos;
+        v2s32 geom;
+
+        // Handle real coordinates if applicable
+        if (data->real_coordinates) {
+            pos = getRealCoordinateBasePos(v_pos);
+            geom = getRealCoordinateGeometry(v_geom);
+        } else {
+            pos = getElementBasePos(&v_pos);
+            geom.X = stof(v_geom[0]) * spacing.X;
+            geom.Y = stof(v_geom[1]) * spacing.Y;
+        }
+
+        video::SColor outline_color;
+        parseColorString(parts[2], outline_color, true, 0xFF);
+
+        core::rect<s32> rect(pos, pos + geom);
+
+		FieldSpec spec(
+			"",
+			L"",
+			L"",
+			258 + m_fields.size(),
+			-2
+		);
+		spec.ftype = f_outline;
+
+
+        GUIOutline *e = new GUIOutline(
+            Environment, data->current_parent, spec.fid, rect, outline_color);
+        e->drop();
+
+        m_fields.push_back(spec);
+        return;
+    }
+	
+
+}
+
 
 bool GUIFormSpecMenu::parseMiddleRect(const std::string &value, core::rect<s32> *parsed_rect)
 {

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -56,7 +56,8 @@ enum FormspecFieldType {
 	f_ItemImage,
 	f_HyperText,
 	f_AnimatedImage,
-	f_Unknown
+	f_Unknown,
+	f_outline
 };
 
 enum FormspecQuitMode {
@@ -492,6 +493,7 @@ private:
 	bool parsePaddingDirect(parserData *data, const std::string &element);
 	void parsePadding(parserData *data, const std::string &element);
 	void parseStyle(parserData *data, const std::string &element);
+	void parseOutline(parserData* data, const std::string &element);
 	void parseSetFocus(parserData *, const std::string &element);
 	void parseModel(parserData *data, const std::string &element);
 

--- a/src/gui/guiOutline.cpp
+++ b/src/gui/guiOutline.cpp
@@ -1,0 +1,44 @@
+/*
+Garud Client
+Copyright (C) 2024 Astra0081, 
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3.0 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "guiOutline.h"
+#include "irrlichttypes_extrabloated.h"
+
+GUIOutline::GUIOutline(gui::IGUIEnvironment* env, gui::IGUIElement* parent,
+                                         s32 id, const core::rect<s32> &rect,
+                                         video::SColor color)
+    : gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rect),
+      m_color(color)
+{
+}
+
+void GUIOutline::draw()
+{
+    if (!IsVisible)
+        return;
+
+    video::IVideoDriver* driver = Environment->getVideoDriver();
+    if (!driver)
+        return;
+
+    core::rect<s32> rect = getAbsoluteClippingRect();
+    driver->draw2DRectangleOutline(rect, m_color);
+
+    gui::IGUIElement::draw();
+}

--- a/src/gui/guiOutline.h
+++ b/src/gui/guiOutline.h
@@ -1,0 +1,33 @@
+/*
+Garud Client
+Copyright (C) 2024 Astra0081, 
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3.0 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "irrlichttypes_extrabloated.h"
+#include "IGUIElement.h"
+
+class GUIOutline : public gui::IGUIElement
+{
+public:
+    GUIOutline(gui::IGUIEnvironment* env, gui::IGUIElement* parent, s32 id,
+                        const core::rect<s32> &rect, video::SColor color);
+
+    virtual void draw() override;
+
+private:
+    video::SColor m_color;
+};


### PR DESCRIPTION
- Goal of the PR
This PR adds a new outline[] element, as the name says it draws an outline with the given positions. This element is purely for visual purposes and aims to add an extra layer of creative expression to formspecs.

This PR is Ready for Review.

- [x] List
- [x] Things
- [x] To do

## How to test
Create a mod with the following code:

```lua
minetest.register_chatcommand("show_outline", {
    description = "Show a test example of outline[] element.",
    func = function(name)
        local formspec = "formspec_version[4]" ..
                         "size[6,6]" ..
                         "label[0.5,0.5;This is an outline:]" ..
                         "outline[1,1;4,2;#00FF00]"

        -- Show the formspec to the player
        minetest.show_formspec(name, "outline_form", formspec)
    end
})
```
Enabe the mod and it should look something like this:

![Uploading garudclient.jpeg…]()
